### PR TITLE
fix: 干掉 JSON.stringify(error)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,6 @@ exports = module.exports = function (app, settings = {}) {
             return render(data);
         } catch (error) {
             delete error.stack;
-            error = JSON.stringify(error, null, 4);
             throw new Error(error);
         }
     }


### PR DESCRIPTION
JSON.stringify(error)

会吃掉异常的实际描述，不适合记录 log